### PR TITLE
Select right value from JSON after changes in API

### DIFF
--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/Ecommerce.Controller.js
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/Ecommerce.Controller.js
@@ -44,10 +44,10 @@
                     // push objects to items array
                     angular.forEach($scope.products.Rows, function (item) {
                         $scope.itemProducts.push({
-                            productSku: item.Cells[0],
-                            productName: item.Cells[1],
-                            quantity: parseInt(item.Cells[2]),
-                            revenue: parseFloat(item.Cells[3])
+                            productSku: item.Cells[0].Value,
+                            productName: item.Cells[1].Value,
+                            quantity: parseInt(item.Cells[2].Value),
+                            revenue: parseFloat(item.Cells[3].Value)
                         });
                     });
 
@@ -77,12 +77,13 @@
                     // push objects to items array
                     angular.forEach($scope.revenuepersource.Rows, function (item) {
                         // only where there have been a transaction
-                        if (parseInt(item.Cells[2]) > 0) {
+                        var numberOfTransactions = parseInt(item.Cells[2].Value);
+                        if (numberOfTransactions > 0) {
                             $scope.itemRevenuePerSource.push({
-                                r_source: item.Cells[0],
-                                r_keyword: item.Cells[1],
-                                r_transactions: parseInt(item.Cells[2]),
-                                r_revenue: parseFloat(item.Cells[3])
+                                r_source: item.Cells[0].Value,
+                                r_keyword: item.Cells[1].Value,
+                                r_transactions: numberOfTransactions,
+                                r_revenue: parseFloat(item.Cells[3].Value)
                             });
                         }
                     });
@@ -108,17 +109,17 @@
                 statsResource.getstoredetails(profileID, $scope.dateFilter.startDate, $scope.dateFilter.endDate).then(function (response) {
                     $scope.storedetails = response.data.ApiResult;
 
-                    var _transactions = $scope.storedetails.Rows[0].Cells[0];
-                    var _transactionRevenue = $scope.storedetails.Rows[0].Cells[1];
-                    var _itemsPerPurchase = $scope.storedetails.Rows[0].Cells[2];
-                    var _itemQuantity = $scope.storedetails.Rows[0].Cells[3];
-                    var _conversionRate = $scope.storedetails.Rows[0].Cells[4];
+                    var _transactions = $scope.storedetails.Rows[0].Cells[0].Value;
+                    var _transactionRevenue = $scope.storedetails.Rows[0].Cells[1].Value;
+                    var _itemsPerPurchase = $scope.storedetails.Rows[0].Cells[2].Value;
+                    var _itemQuantity = $scope.storedetails.Rows[0].Cells[3].Value;
+                    var _conversionRate = $scope.storedetails.Rows[0].Cells[4].Value;
 
                     $scope.info = {
                         transactions: parseInt(_transactions),
                         revenue: 0.0,
                         avgRevenue: 0.0,
-                        itemsPerPurchase: parseFloat(_itemsPerPurchase),
+                        itemsPerPurchase: parseFloat(_itemsPerPurchase).toFixed(2),
                         itemQuantity: parseInt(_itemQuantity),
                         conversionRate: parseFloat(_conversionRate)
                     }

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/ProductPerformance.Controller.js
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/ProductPerformance.Controller.js
@@ -89,12 +89,12 @@
                     // push objects to items array
                     angular.forEach($scope.productperformance.Rows, function (item) {
                         $scope.itemProducts.push({
-                            productSku: item.Cells[0],
-                            productName: item.Cells[1],
-                            uniquePurchases: parseInt(item.Cells[2]),
-                            revenue: parseFloat(item.Cells[3]),
-                            revenuePerItem: parseFloat(item.Cells[4]),
-                            itemsPerPurchase: parseFloat(item.Cells[5])
+                            productSku: item.Cells[0].Value,
+                            productName: item.Cells[1].Value,
+                            uniquePurchases: parseInt(item.Cells[2].Value),
+                            revenue: parseFloat(item.Cells[3].Value),
+                            revenuePerItem: parseFloat(item.Cells[4].Value),
+                            itemsPerPurchase: parseFloat(item.Cells[5].Value).toFixed(2)
                         });
                     });
 

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/SalesPerformance.Controller.js
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/SalesPerformance.Controller.js
@@ -88,13 +88,13 @@
                     $scope.itemSales.length = 0;
                     // push objects to items array
                     angular.forEach($scope.salesperformance.Rows, function (item) {
-                        var year = item.Cells[0].slice(0, 4);
-                        var month = item.Cells[0].slice(4, 6);
-                        var day = item.Cells[0].slice(6, 8);
+                        var year = item.Cells[0].Value.slice(0, 4);
+                        var month = item.Cells[0].Value.slice(4, 6);
+                        var day = item.Cells[0].Value.slice(6, 8);
                         $scope.itemSales.push({
                             date: new Date(year, month, day), // yyyyMMdd --> yyyy-MM-dd
-                            uniquePurchases: parseInt(item.Cells[2]),
-                            revenue: parseFloat(item.Cells[1])
+                            uniquePurchases: parseInt(item.Cells[2].Value),
+                            revenue: parseFloat(item.Cells[1].Value)
                         });
                     });
 

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/Transaction.Controller.js
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/controllers/Transaction.Controller.js
@@ -89,9 +89,9 @@
                     // push objects to items array
                     angular.forEach($scope.transactions.Rows, function (item) {
                         $scope.itemTransactions.push({
-                            transactionId: item.Cells[0],
-                            quantity: parseInt(item.Cells[1]),
-                            revenue: parseFloat(item.Cells[2])
+                            transactionId: item.Cells[0].Value,
+                            quantity: parseInt(item.Cells[1].Value),
+                            revenue: parseFloat(item.Cells[2].Value)
                         });
                     });
 

--- a/Analytics/App_Plugins/Analytics/css/analytics.css
+++ b/Analytics/App_Plugins/Analytics/css/analytics.css
@@ -111,9 +111,9 @@ table.table a span:hover {
     margin-top: 20px;
 }
 #stat-boxes .box-info {
-    width: 200px;
+    width: 220px;
     padding: 15px;
-    margin: 0px 15px 15px 0px;
+    margin: 0 15px 15px 0;
     border: 1px solid #ccc;
     display: block;
     min-height: 65px;


### PR DESCRIPTION
The eCommerce part i Analytics was using the old values, which after
some changes in the API now just returned JSON string - so it is updated
to use Value property. Furthermore Avg. Items Per Purchase is not
neccessary a whole integer, where it could return a lot of decimals -
fixed to 2 decimals. And also made the boxes a bit wider to better fit
larger number like 100K or 1 million.