### PR TITLE
Typo in ng-repeat for transactions

### DIFF
--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/transactions.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/transactions.html
@@ -24,7 +24,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="item in itemTransactionsg" ts-repeat>
+                <tr ng-repeat="item in itemTransactions" ts-repeat>
                     <td>{{ item.transactionId }}</td>
                     <td>{{ item.revenue | currency: currencyCode }}</td>
                     <td>{{ item.quantity }}</td>


### PR DESCRIPTION
Typo in ng-repeat for transactions, which cause no data shown in table.