### PR TITLE
Missing translations - must be case sensitive

### DIFF
--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/os.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/os.html
@@ -18,7 +18,7 @@
         <table id="tbl-os" class="table table-striped" ts-wrapper>
             <thead>
                 <tr>
-                    <th id="operatingsystem" ts-criteria="operatingsystem"><localize key="analytics_operatingsystem">Operating System</localize></th>
+                    <th id="operatingsystem" ts-criteria="operatingsystem"><localize key="analytics_operatingSystem">Operating System</localize></th>
                     <th id="visits" ts-criteria="visits | parseInt" ts-default="descending"><localize key="analytics_visits">Visits</localize></th>
                     <th id="pageviews" ts-criteria="pageviews | parseInt"><localize key="analytics_pageViews">Page Views</localize></th>
                 </tr>
@@ -39,7 +39,7 @@
         <table id="tbl-osversions" class="table table-striped" ts-wrapper>
             <thead>
                 <tr>
-                    <th id="v_operatingsystem" ts-criteria="v_operatingsystem"><localize key=" analytics_operatingsystem">Operating System</localize></th>
+                    <th id="v_operatingsystem" ts-criteria="v_operatingsystem"><localize key=" analytics_operatingSystem">Operating System</localize></th>
                     <th id="v_version" ts-criteria="v_version"><localize key=" analytics_version">Version</localize></th>
                     <th id="v_visits" ts-criteria="v_visits | parseInt" ts-default="descending"><localize key="analytics_visits">Visits</localize></th>
                     <th id="v_pageviews" ts-criteria="v_pageviews | parseInt"><localize key="analytics_pageViews">Page Views</localize></th>

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/productperformance.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/productperformance.html
@@ -19,8 +19,8 @@
         <table id="tbl-productperformance" class="table table-striped" ts-wrapper>
             <thead>
                 <tr>
-                    <th id="productSku" ts-criteria="productSku"><localize key="analytics_productsku">Product SKU</localize></th>
-                    <th id="productName" ts-criteria="productName"><localize key="analytics_productname">Product Name</localize></th>
+                    <th id="productSku" ts-criteria="productSku"><localize key="analytics_productSku">Product SKU</localize></th>
+                    <th id="productName" ts-criteria="productName"><localize key="analytics_productName">Product Name</localize></th>
                     <th id="uniquePurchases" ts-criteria="uniquePurchases | parseInt"><localize key="analytics_uniquePurchases">Unique Purchases</localize></th>
                     <th id="revenue" ts-criteria="revenue | parseFloat" ts-default="descending"><localize key="analytics_revenue">Revenue</localize></th>
                     <th id="revenuePerItem" ts-criteria="revenuePerItem | parseFloat"><localize key="analytics_revenuePerItem">Revenue Per Item</localize></th>

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/social.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/social.html
@@ -18,7 +18,7 @@
         <table id="tbl-social" class="table table-striped" ts-wrapper>
             <thead>
                 <tr>
-                    <th id="socialnetwork" ts-criteria="socialnetwork"><localize key="analytics_socialnetwork">Social Network</localize></th>
+                    <th id="socialnetwork" ts-criteria="socialnetwork"><localize key="analytics_socialNetwork">Social Network</localize></th>
                     <th id="visits" ts-criteria="visits | parseInt" ts-default="descending"><localize key="analytics_visits">Visits</localize></th>
                     <th id="pageviews" ts-criteria="pageviews | parseInt"><localize key="analytics_pageViews">Page Views</localize></th>
                 </tr>

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/transactions.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/transactions.html
@@ -24,7 +24,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="item in itemTransactionsg" ts-repeat>
+                <tr ng-repeat="item in itemTransactions" ts-repeat>
                     <td>{{ item.transactionId }}</td>
                     <td>{{ item.revenue | currency: currencyCode }}</td>
                     <td>{{ item.quantity }}</td>

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/transactions.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/transactions.html
@@ -24,7 +24,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="item in itemTransactions" ts-repeat>
+                <tr ng-repeat="item in itemTransactionsg" ts-repeat>
                     <td>{{ item.transactionId }}</td>
                     <td>{{ item.revenue | currency: currencyCode }}</td>
                     <td>{{ item.quantity }}</td>

--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/views.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/views.html
@@ -17,7 +17,7 @@
         <table id="tbl-views" class="table table-striped" ts-wrapper>
             <thead>
                 <tr>
-                    <th id="pagepath" ts-criteria="pagepath"><localize key="analytics_pagepath">Page Path</localize></th>
+                    <th id="pagepath" ts-criteria="pagepath"><localize key="analytics_pagePath">Page Path</localize></th>
                     <th id="visits" ts-criteria="visits | parseInt" ts-default="descending"><localize key="analytics_visits">Visits</localize></th>
                     <th id="pageviews" ts-criteria="pageviews | parseInt"><localize key="analytics_pageViews">Page Views</localize></th>
                 </tr>
@@ -38,7 +38,7 @@
         <table id="tbl-sources" class="table table-striped" ts-wrapper>
             <thead>
                 <tr>
-                    <th id="s_source" ts-criteria="s_source"><localize key=" analytics_source">Source</localize></th>
+                    <th id="s_source" ts-criteria="s_source"><localize key="analytics_source">Source</localize></th>
                     <th id="s_visits" ts-criteria="s_visits | parseInt" ts-default="descending"><localize key="analytics_visits">Visits</localize></th>
                     <th id="s_pageviews" ts-criteria="s_pageviews | parseInt"><localize key="analytics_pageViews">Page Views</localize></th>
                 </tr>


### PR DESCRIPTION
Typo in ng-repeat for translations and missing translations on table header columns, because of lowercase keys - the keys are case sensitive.