### PR TITLE
Typo in ts-criteria on table header

### DIFF
--- a/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/keywords.html
+++ b/Analytics/App_Plugins/Analytics/backOffice/AnalyticsTree/partials/keywords.html
@@ -16,7 +16,7 @@
                 <tr>
                     <th id="keyword" ts-criteria="keyword"><localize key="analytics_keyword">Keyword</localize></th>
                     <th id="visits" ts-criteria="visits | parseInt" ts-default="descending"><localize key="analytics_visits">Visits</localize></th>
-                    <th id="pageviews" ts-critera="pageviews | parseInt"><localize key="analytics_pageViews">Page Views</localize></th>
+                    <th id="pageviews" ts-criteria="pageviews | parseInt"><localize key="analytics_pageViews">Page Views</localize></th>
                 </tr> 
             </thead>
             <tbody>


### PR DESCRIPTION
Typo in ts-criteria on table header, which cause the Page Views column
for Keywords table was not sortable.