### PR TITLE
Implement new build naming & numbering

### DIFF
--- a/BuildPackage/Tools/AppVeyorUmbraco/AppVeyorUmbraco.Targets
+++ b/BuildPackage/Tools/AppVeyorUmbraco/AppVeyorUmbraco.Targets
@@ -4,21 +4,43 @@
     TaskFactory="CodeTaskFactory"
     AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
 	<ParameterGroup>
-      <BuildVersion ParameterType="System.String" Required="true" />
+    <BuildVersion ParameterType="System.String" Required="true" />
 	  <BuildSuffix ParameterType="System.String" Required="false" />
 	  <ProductVersion ParameterType="System.String" Output="true" />
+  	<Release ParameterType="System.String" Required="true" />
 	</ParameterGroup>	
     <Task>
       <Using Namespace="System"/>
       <Using Namespace="System.IO"/>
       <Code Type="Fragment" Language="cs">
 <![CDATA[
-            var baseVersion = BuildVersion.Substring(0, BuildVersion.LastIndexOf('.'));
-            if (string.IsNullOrEmpty(BuildSuffix)){
-			        ProductVersion = baseVersion;
-            } else {
-              ProductVersion = baseVersion + "-" + BuildSuffix;
+            var pos = BuildVersion.LastIndexOf('.');
+            var len = BuildVersion.Length - pos - 1;
+            
+            var buildNumberWithZeros = BuildVersion.Substring(pos + 1, len).PadLeft(6, '0');
+
+            var baseVersion = BuildVersion.Substring(0, pos);
+
+            if ((string.IsNullOrEmpty(BuildSuffix) || BuildSuffix == "rtm") && Release == "true")
+            {
+                ProductVersion = baseVersion;
             }
+            else if (string.IsNullOrEmpty(BuildSuffix) && Release == "false")
+            {
+                ProductVersion = baseVersion + "-alpha-" + buildNumberWithZeros;
+            }
+            else if (!string.IsNullOrEmpty(BuildSuffix) && Release == "true")
+            {
+                ProductVersion = baseVersion + "-" + BuildSuffix;
+            }
+            else if (!string.IsNullOrEmpty(BuildSuffix) && BuildSuffix != "rtm" && Release == "false")
+            {
+                ProductVersion = baseVersion + "-" + BuildSuffix + "-" + buildNumberWithZeros;
+            }
+            else
+            {
+                ProductVersion = "";
+            }          
 //Log.LogError(OutputVer);
 ]]>
       </Code>

--- a/BuildPackage/package.proj
+++ b/BuildPackage/package.proj
@@ -81,7 +81,7 @@
 
   <!-- TARGETS -->
   <Target Name="GetProductVersion">
-    <Error Condition="$(AbortBuild) == 'true'" Text="Aborting the build as the UMBRACO_PACKAGE_PRERELEASE_SUFFIX suffix is set 'rtm' but APPVEYOR_REPO_BRANCH is not 'release'" />
+    <Error Condition="$(AbortBuild) == 'true'" Text="Aborting the build as the UMBRACO_PACKAGE_PRERELEASE_SUFFIX suffix is set 'rtm' but APPVEYOR_REPO_BRANCH is not 'master'" />
     <GetProductVersion BuildVersion="$(APPVEYOR_BUILD_VERSION)" BuildSuffix="$(UMBRACO_PACKAGE_PRERELEASE_SUFFIX)" Release="$(Release)">
       <Output TaskParameter="ProductVersion" PropertyName="ProductVersion"/>
     </GetProductVersion>

--- a/BuildPackage/package.proj
+++ b/BuildPackage/package.proj
@@ -45,12 +45,25 @@
   <Choose>
     <When Condition="$(APPVEYOR_BUILD_NUMBER) != '' And $(APPVEYOR_REPO_BRANCH) != 'master' ">
       <PropertyGroup>
-        <VersionSuffix>build$(APPVEYOR_BUILD_NUMBER)</VersionSuffix>
+        <Release>false</Release>
       </PropertyGroup>
     </When>
     <Otherwise>
       <PropertyGroup>
-        <VersionSuffix>$(UMBRACO_PACKAGE_PRERELEASE_SUFFIX)</VersionSuffix>
+        <Release>true</Release>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <Choose>
+    <When Condition="$(Release) == 'false' And $(UMBRACO_PACKAGE_PRERELEASE_SUFFIX) == 'rtm'">
+      <PropertyGroup>
+        <AbortBuild>true</AbortBuild>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <AbortBuild>false</AbortBuild>
       </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -68,7 +81,8 @@
 
   <!-- TARGETS -->
   <Target Name="GetProductVersion">
-    <GetProductVersion BuildVersion="$(APPVEYOR_BUILD_VERSION)" BuildSuffix="$(VersionSuffix)">
+    <Error Condition="$(AbortBuild) == 'true'" Text="Aborting the build as the UMBRACO_PACKAGE_PRERELEASE_SUFFIX suffix is set 'rtm' but APPVEYOR_REPO_BRANCH is not 'release'" />
+    <GetProductVersion BuildVersion="$(APPVEYOR_BUILD_VERSION)" BuildSuffix="$(UMBRACO_PACKAGE_PRERELEASE_SUFFIX)" Release="$(Release)">
       <Output TaskParameter="ProductVersion" PropertyName="ProductVersion"/>
     </GetProductVersion>
   </Target>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,17 @@
 # version format
 version: 1.1.0.{build}
 
-# UMBRACO_PACKAGE_PRERELEASE_SUFFIX will only be used for Release builds
-# example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta
-install:
-  - cmd: set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=
-  - cmd: cd BuildPackage
-  - cmd: Build.bat
+# Do not build on tags
+skip_tags: true
 
-# to disable automatic builds and use our build.bat file with MSBUILD above
-build: off
+# UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
+# example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta
+init:
+- set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=
+
+build_script:
+- cd BuildPackage
+- Build.bat
 
 artifacts:
   - path: BuildPackage\artifacts\*.nupkg


### PR DESCRIPTION
This new approach to build number & naming comes from discussions and implementation I've done for Ditto. This numbering is almost SemVer2 but not quite as NuGet doesn't fully support it yet, this is the same approach as Microsoft are using for their projects.

Six digit leading zero build numbers

Build numbers suffixed with a hyphen, e.g. "1.1.0-alpha-000022"

CI builds always have a suffix, by default "alpha" but could also be "beta"

If using "beta" CI build and then want to move to RTM, can now use special "rtm" suffix, set UMBRACO_PACKAGE_PRERELEASE_SUFFIX = rtm, when you release , one build will be the released and will be successful, the other will intentionally fail to avoid a invalid CI build.

This allows this full release pattern if you want it:

	version: 1.1.0.{build}
	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=

		CI > 1.1.0-alpha-0012
		CI > 1.1.0-alpha-0013

	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=alpha
	APPVEYOR_REPO_BRANCH=master

		Release >1.1.0-alpha

	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta

		CI > 1.1.0-beta-0015

	APPVEYOR_REPO_TAG=true

		Release > 1.1.0-beta

	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=rtm
	APPVEYOR_REPO_BRANCH=master

	(this is where a CI build would normally be created as well as the release, it would be 1.1.0-alpha-0017, but instead it will be aborted)

		Release > 1.1.0

Currently Analytics has only CI builds and releases so nothing needs to be changed.

When switching to this new numbering I would recommend that any existing NuGet packages for v1.1.0 are deleted (hidden) from the feed so that the order starts to work in Visual Studio.